### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Pillow>=4.0.0
 scipy==0.19.1
 tensorflow>=1.2.1
 numpy>=1.13.1
-keras
+keras>=2.0.0
 h5py


### PR DESCRIPTION
You might want to make the version number even higher here, but before keras 1.1.0 you'll get the error: `ModuleNotFoundError: No module named 'keras.applications'`. Before keras 2.0.0 you'll get the error: `ImportError: cannot import name 'conv_utils'`