### PR TITLE
Specify TensorFlow backend in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Install the pre-requisites
 
 Run locally (this will likely be very slow as it runs on your GPU)
 
-    python3 synthesize.py -s bark.jpg
+    KERAS_BACKEND=tensorflow python3 synthesize.py -s bark.jpg
 
 Look for output files inside the "outputs" directory that will be created by this command.
 


### PR DESCRIPTION
If I let this default to the the Theano backend, I get:

```
Traceback (most recent call last):
  File "synthesize.py", line 91, in <module>
    pyramid_model = gram.make_pyramid_model(args.octaves, args.padding_mode)
  File "/Users/ryan/mess/2017/42/subjective-functions/gram.py", line 237, in make_pyramid_model
    level = reduce_layer(padding_mode=padding_mode)(gaussian_pyramid[-1])
  File "/usr/local/lib/python3.6/site-packages/keras/engine/topology.py", line 545, in __call__
    output = self.call(inputs, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/keras/layers/core.py", line 659, in call
    return self.function(inputs, **arguments)
  File "/Users/ryan/mess/2017/42/subjective-functions/gram.py", line 148, in fn
    return K.conv2d(K.conv2d(x, kernel_3d, strides=(2,1)),
  File "/usr/local/lib/python3.6/site-packages/keras/backend/theano_backend.py", line 1691, in conv2d
    kernel_shape = kernel.eval().shape
AttributeError: 'numpy.ndarray' object has no attribute 'eval'
```